### PR TITLE
Add support for `handlers`

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function toEstree(tree, options) {
     handle: zwitch('type', {
       invalid: invalid,
       unknown: unknown,
-      handlers: handlers
+      handlers: Object.assign({}, handlers, options.handlers)
     })
   }
   var result = context.handle(tree, context)
@@ -417,7 +417,9 @@ function all(parent, context) {
 
   while (++index < children.length) {
     result = context.handle(children[index], context)
-    if (result) {
+    if (Array.isArray(result)) {
+      results = results.concat(result)
+    } else {
       results.push(result)
     }
   }

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function toEstree(tree, options) {
     handle: zwitch('type', {
       invalid: invalid,
       unknown: unknown,
-      handlers: Object.assign({}, handlers, options.handlers)
+      handlers: Object.assign({}, handlers, options && options.handlers)
     })
   }
   var result = context.handle(tree, context)
@@ -419,7 +419,7 @@ function all(parent, context) {
     result = context.handle(children[index], context)
     if (Array.isArray(result)) {
       results = results.concat(result)
-    } else {
+    } else if (result) {
       results.push(result)
     }
   }

--- a/test.js
+++ b/test.js
@@ -443,6 +443,56 @@ test('hast-util-to-estree', function (t) {
     'should support an custom `mdxJsxTextElement` node w/o name, attributes, or children'
   )
 
+  t.deepEqual(
+    toEstree(
+      {
+        type: 'root',
+        children: [
+          {
+            type: 'array',
+            value: 'comma,seperated,array'
+          }
+        ]
+      },
+      {
+        handlers: {
+          array: (node) => {
+            var elements = node.value.split(',').map((v) => ({
+              type: 'Literal',
+              value: v
+            }))
+            return elements
+          }
+        }
+      }
+    ),
+    {
+      type: 'Program',
+      body: [
+        {
+          type: 'ExpressionStatement',
+          expression: {
+            type: 'JSXFragment',
+            openingFragment: {
+              type: 'JSXOpeningFragment',
+              attributes: [],
+              selfClosing: false
+            },
+            closingFragment: {type: 'JSXClosingFragment'},
+            children: [
+              {type: 'Literal', value: 'comma'},
+              {type: 'Literal', value: 'seperated'},
+              {type: 'Literal', value: 'array'}
+            ]
+          }
+        }
+      ],
+      sourceType: 'module',
+      comments: []
+    },
+    'should support custom handler that returns an array'
+  )
+
   t.end()
 })
 


### PR DESCRIPTION
this is for issue #1, it also handles handlers that return an array of nodes.

- add the ability to customize handlers via options
- add tests
