### PR TITLE
Fix MDX node types

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,20 +27,17 @@
  * @typedef {EstreeJsxOpeningElement['name']} EstreeJsxElementName
  * @typedef {EstreeJsxAttribute['name']} EstreeJsxAttributeName
  * @typedef {EstreeJsxElement['children'][number]} EstreeJsxChild
- * @typedef {Element['children'][number]} ElementChild
  *
- * @typedef {UnistNode & {type: 'mdxJsxAttributeValueExpression', value: string}} MDXJsxAttributeValueExpression
- * @typedef {UnistNode & {type: 'mdxJsxAttribute', name: string, value: (MDXJsxAttributeValueExpression|string)?}} MDXJsxAttribute
- * @typedef {UnistNode & {type: 'mdxJsxExpressionAttribute', value: string}} MDXJsxExpressionAttribute
- * @typedef {Parent & {name: string|null, attributes: Array.<MDXJsxExpressionAttribute|MDXJsxAttribute>}} MDXJsxElement
- * @typedef {MDXJsxElement & {type: 'mdxJsxFlowElement', children: Array.<MDXJsxFlowElement|ElementChild>}} MDXJsxFlowElement
- * @typedef {MDXJsxElement & {type: 'mdxJsxTextElement', children: Array.<MDXJsxTextElement|ElementChild>}} MDXJsxTextElement
+ * @typedef {import('mdast-util-mdx-jsx').MDXJsxAttributeValueExpression} MDXJsxAttributeValueExpression
+ * @typedef {import('mdast-util-mdx-jsx').MDXJsxAttribute} MDXJsxAttribute
+ * @typedef {import('mdast-util-mdx-jsx').MDXJsxExpressionAttribute} MDXJsxExpressionAttribute
+ * @typedef {import('mdast-util-mdx-jsx').MDXJsxFlowElement} MDXJsxFlowElement
+ * @typedef {import('mdast-util-mdx-jsx').MDXJsxTextElement} MDXJsxTextElement
  *
- * @typedef {UnistNode & {value: string}} MDXExpression
- * @typedef {MDXExpression & {type: 'mdxFlowExpression'}} MDXFlowExpression
- * @typedef {MDXExpression & {type: 'mdxTextExpression'}} MDXTextExpression
+ * @typedef {import('mdast-util-mdx-expression').MDXFlowExpression} MDXFlowExpression
+ * @typedef {import('mdast-util-mdx-expression').MDXTextExpression} MDXTextExpression
  *
- * @typedef {UnistNode & {type: 'mdxjsEsm', value: string}} MDXEsm
+ * @typedef {import('mdast-util-mdxjs-esm').MDXJSEsm} MDXJSEsm
  *
  * @typedef {ReturnType<find>} Info
  * @typedef {'html'|'svg'} Space
@@ -307,7 +304,7 @@ function element(node, context) {
 }
 
 /**
- * @param {MDXEsm} node
+ * @param {MDXJSEsm} node
  * @param {Context} context
  * @returns {void}
  */
@@ -546,7 +543,7 @@ function text(node) {
 }
 
 /**
- * @param {Parent} parent
+ * @param {Parent|MDXJsxFlowElement|MDXJsxTextElement} parent
  * @param {Context} context
  * @returns {Array.<EstreeJsxChild>}
  */

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "estree-util-attach-comments": "^2.0.0",
     "estree-util-is-identifier-name": "^2.0.0",
     "hast-util-whitespace": "^2.0.0",
+    "mdast-util-mdx-expression": "^1.0.0",
+    "mdast-util-mdxjs-esm": "^1.0.0",
     "property-information": "^6.0.0",
     "space-separated-tokens": "^2.0.0",
     "style-to-object": "^0.3.0",


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

- In `MDXJsxAttributeValueExpression`, `value` is optional.
- The `data` property of `MDXJsxAttributeValueExpression` is an estree program.
- In `MDXJsxAttribute`, `value` is optional.
- In `MDXEsm`, `value` is optional.

<!--do not edit: pr-->
