### PR TITLE
Add `preserveHtmlProp` option

### DIFF
--- a/lib/handlers/element.js
+++ b/lib/handlers/element.js
@@ -66,7 +66,7 @@ export function element(node, state) {
       }
 
       prop =
-        state.jsxStyle === 'react' && info.space
+        !state.preserveHtmlProp && info.space
           ? hastToReact[info.property] || info.property
           : info.attribute
 

--- a/lib/handlers/element.js
+++ b/lib/handlers/element.js
@@ -112,10 +112,10 @@ export function element(node, state) {
         attributeValue = {type: 'Literal', value: String(value)}
       }
 
-      if (jsxIdentifierName(prop, state.jsxStyle === 'html')) {
+      if (jsxIdentifierName(prop)) {
         attributes.push({
           type: 'JSXAttribute',
-          name: state.createJsxAttributeName(prop),
+          name: {type: 'JSXIdentifier', name: prop},
           value: attributeValue
         })
       } else {
@@ -229,12 +229,10 @@ function styleReplacer(_, $1) {
  *
  * @param {string} name
  *   Whatever.
- * @param {boolean} [allowColon=false]
- *   Allow colons for some JSX flavours.
  * @returns {boolean}
  *   Whether `name` is a valid JSX identifier.
  */
-function jsxIdentifierName(name, allowColon = false) {
+function jsxIdentifierName(name) {
   let index = -1
 
   while (++index < name.length) {
@@ -249,10 +247,6 @@ function jsxIdentifierName(name, allowColon = false) {
    * @returns {boolean}
    */
   function cont(code) {
-    return (
-      identifierCont(code) ||
-      code === 45 /* `-` */ ||
-      (allowColon && code === 58) /* `:` */
-    )
+    return identifierCont(code) || code === 45 /* `-` */
   }
 }

--- a/lib/handlers/element.js
+++ b/lib/handlers/element.js
@@ -65,9 +65,10 @@ export function element(node, state) {
         continue
       }
 
-      prop = info.space
-        ? hastToReact[info.property] || info.property
-        : info.attribute
+      prop =
+        state.jsxStyle === 'react' && info.space
+          ? hastToReact[info.property] || info.property
+          : info.attribute
 
       if (Array.isArray(value)) {
         // Accept `array`.
@@ -111,10 +112,10 @@ export function element(node, state) {
         attributeValue = {type: 'Literal', value: String(value)}
       }
 
-      if (jsxIdentifierName(prop)) {
+      if (jsxIdentifierName(prop, state.jsxStyle === 'html')) {
         attributes.push({
           type: 'JSXAttribute',
-          name: {type: 'JSXIdentifier', name: prop},
+          name: state.createJsxAttributeName(prop),
           value: attributeValue
         })
       } else {
@@ -228,10 +229,12 @@ function styleReplacer(_, $1) {
  *
  * @param {string} name
  *   Whatever.
+ * @param {boolean} [allowColon=false]
+ *   Allow colons for some JSX flavours.
  * @returns {boolean}
  *   Whether `name` is a valid JSX identifier.
  */
-function jsxIdentifierName(name) {
+function jsxIdentifierName(name, allowColon = false) {
   let index = -1
 
   while (++index < name.length) {
@@ -246,6 +249,10 @@ function jsxIdentifierName(name) {
    * @returns {boolean}
    */
   function cont(code) {
-    return identifierCont(code) || code === 45 /* `-` */
+    return (
+      identifierCont(code) ||
+      code === 45 /* `-` */ ||
+      (allowColon && code === 58) /* `:` */
+    )
   }
 }

--- a/lib/state.js
+++ b/lib/state.js
@@ -57,17 +57,17 @@
  *   it.
  * @property {Record<string, Handle | null | undefined> | null | undefined} [handlers={}]
  *   Custom handlers.
- * @property {'react' | 'html'} [jsxStyle='react']
- *   Style of JSX to produce. For example, `react` would generate property names
- *   like `xlinkHref`, while `html` would generate `xlink:href`. Some JSX
- *   runtimes may not support React's JSX style, so `html` can be used instead.
+ * @property {boolean} [preserveHtmlProp=false]
+ *   Whether to produce JSX props using HTML-style naming, e.g. `xlink:href`
+ *   instead of `xlinkHref`.
  *
  * @typedef State
  *   Info passed around about the current state.
  * @property {Schema} schema
  *   Current schema.
- * @property {'react' | 'html'} jsxStyle
- *   Style of JSX to produce.
+ * @property {boolean} preserveHtmlProp
+ *   Whether to produce JSX props using HTML-style naming, e.g. `xlink:href`
+ *   instead of `xlinkHref`.
  * @property {Array<Comment>} comments
  *   List of estree comments.
  * @property {Array<Directive | Statement | ModuleDeclaration>} esm
@@ -123,7 +123,7 @@ export function createState(options) {
   return {
     // Current space.
     schema: options.space === 'svg' ? svg : html,
-    jsxStyle: options.jsxStyle || 'react',
+    preserveHtmlProp: Boolean(options.preserveHtmlProp),
     // Results.
     comments: [],
     esm: [],

--- a/lib/state.js
+++ b/lib/state.js
@@ -227,6 +227,7 @@ function all(parent) {
  *   Nothing.
  */
 function inherit(from, to) {
+  // @ts-expect-error Test data field only
   const left = from.data
   /** @type {Record<string, unknown> | undefined} */
   let right

--- a/lib/state.js
+++ b/lib/state.js
@@ -57,11 +57,17 @@
  *   it.
  * @property {Record<string, Handle | null | undefined> | null | undefined} [handlers={}]
  *   Custom handlers.
+ * @property {'react' | 'html'} [jsxStyle='react']
+ *   Style of JSX to produce. For example, `react` would generate property names
+ *   like `xlinkHref`, while `html` would generate `xlink:href`. Some JSX
+ *   runtimes may not support React's JSX style, so `html` can be used instead.
  *
  * @typedef State
  *   Info passed around about the current state.
  * @property {Schema} schema
  *   Current schema.
+ * @property {'react' | 'html'} jsxStyle
+ *   Style of JSX to produce.
  * @property {Array<Comment>} comments
  *   List of estree comments.
  * @property {Array<Directive | Statement | ModuleDeclaration>} esm
@@ -117,6 +123,7 @@ export function createState(options) {
   return {
     // Current space.
     schema: options.space === 'svg' ? svg : html,
+    jsxStyle: options.jsxStyle || 'react',
     // Results.
     comments: [],
     esm: [],

--- a/readme.md
+++ b/readme.md
@@ -232,6 +232,15 @@ Object mapping node types to functions handling the corresponding nodes
 Merged into the defaults.
 See [`Handle`][handle].
 
+###### `jsxStyle`
+
+The style of JSX to produce (`'react' | 'html'`, default: `'react'`).
+
+For example, `react` would generate property names like `xlinkHref`, while
+`html` would generate `xlink:href`.
+Some JSX runtimes may not support React’s JSX style, so `html` can be used
+instead.
+
 ### `Space`
 
 Namespace (TypeScript type).

--- a/readme.md
+++ b/readme.md
@@ -232,14 +232,10 @@ Object mapping node types to functions handling the corresponding nodes
 Merged into the defaults.
 See [`Handle`][handle].
 
-###### `jsxStyle`
+###### `preserveHtmlProp`
 
-The style of JSX to produce (`'react' | 'html'`, default: `'react'`).
-
-For example, `react` would generate property names like `xlinkHref`, while
-`html` would generate `xlink:href`.
-Some JSX runtimes may not support React’s JSX style, so `html` can be used
-instead.
+Whether to produce JSX props using HTML-style naming, e.g. `xlink:href` instead
+of `xlinkHref` (`boolean`, default: `false`).
 
 ### `Space`
 

--- a/test.js
+++ b/test.js
@@ -481,7 +481,7 @@ test('toEstree', () => {
   )
 
   assert.deepEqual(
-    toEstree(s('x', {xlinkHref: '#test'}), {jsxStyle: 'html'}),
+    toEstree(s('x', {xlinkHref: '#test'}), {preserveHtmlProp: true}),
     acornClean(acornParse('<x {...{"xlink:href": "#test"}}/>')),
     'should support SVG w/ namespaced attribute'
   )

--- a/test.js
+++ b/test.js
@@ -481,6 +481,12 @@ test('toEstree', () => {
   )
 
   assert.deepEqual(
+    toEstree(s('x', {xlinkHref: '#test'}), {jsxStyle: 'html'}),
+    acornClean(acornParse('<x xlink:href="#test"/>')),
+    'should support SVG w/ namespaced attribute'
+  )
+
+  assert.deepEqual(
     toEstree({
       type: 'element',
       tagName: 'p',

--- a/test.js
+++ b/test.js
@@ -482,7 +482,7 @@ test('toEstree', () => {
 
   assert.deepEqual(
     toEstree(s('x', {xlinkHref: '#test'}), {jsxStyle: 'html'}),
-    acornClean(acornParse('<x xlink:href="#test"/>')),
+    acornClean(acornParse('<x {...{"xlink:href": "#test"}}/>')),
     'should support SVG w/ namespaced attribute'
   )
 

--- a/test.js
+++ b/test.js
@@ -846,7 +846,6 @@ test('integration (micromark-extension-mdxjs, mdast-util-mdx)', () => {
 
     const hast = toHast(mdast, {passThrough})
 
-    // @ts-expect-error: hush.
     if (clean && hast) visit(hast, passThrough, acornClean)
 
     // @ts-expect-error: it’s a node.
@@ -929,9 +928,9 @@ test('integration (@babel/plugin-transform-react-jsx, react)', () => {
   assert.deepEqual(
     transform('# Hi <Icon /> {"!"}', {runtime: 'automatic'}),
     [
-      'import { Fragment as _Fragment } from "react/jsx-runtime";',
       'import { jsx as _jsx } from "react/jsx-runtime";',
       'import { jsxs as _jsxs } from "react/jsx-runtime";',
+      'import { Fragment as _Fragment } from "react/jsx-runtime";',
       '/*#__PURE__*/_jsx(_Fragment, {',
       '  children: /*#__PURE__*/_jsxs("h1", {',
       '    children: ["Hi ", /*#__PURE__*/_jsx(Icon, {}), " ", "!"]',
@@ -943,7 +942,7 @@ test('integration (@babel/plugin-transform-react-jsx, react)', () => {
 
   assert.deepEqual(
     transform('# Hi <Icon /> {"!"}', {pragma: 'a', pragmaFrag: 'b'}),
-    'a("b", null, a("h1", null, "Hi ", a(Icon, null), " ", "!"));',
+    'a(b, null, a("h1", null, "Hi ", a(Icon, null), " ", "!"));',
     'should integrate w/ `@babel/plugin-transform-react-jsx` (pragma, pragmaFrag)'
   )
 
@@ -954,9 +953,9 @@ test('integration (@babel/plugin-transform-react-jsx, react)', () => {
     ),
     [
       'import /* a */a from "b";',
-      'import { Fragment as _Fragment } from "react/jsx-runtime";',
       'import { jsx as _jsx } from "react/jsx-runtime";',
       'import { jsxs as _jsxs } from "react/jsx-runtime";',
+      'import { Fragment as _Fragment } from "react/jsx-runtime";',
       '/*#__PURE__*/_jsx(_Fragment, {',
       '  children: /*#__PURE__*/_jsxs("h1", {',
       '    children: [" ", /*#__PURE__*/_jsx("x", {',
@@ -1080,7 +1079,6 @@ test('integration (@vue/babel-plugin-jsx, Vue 3)', () => {
 function acornClean(node) {
   node.sourceType = 'module'
 
-  // @ts-expect-error acorn
   walk(node, {enter})
 
   return JSON.parse(JSON.stringify(node))


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Add `preserveHtmlProp` option to control the style of prop name produced:

`preserveHtmlProp: false` (default):

```jsx
<>
  <x xlinkHref="#test" />
</>
```

`preserveHtmlProp: true`:

```jsx
<>
  <x xlink:href="#test" />
</>
```

Some JSX runtimes, like [Preact](https://preactjs.com/guide/v10/differences-to-react#raw-html-attributeproperty-names), [Solid](https://playground.solidjs.com/anonymous/76c201ff-03ff-49f3-8ecb-268b7bec2aec), and [Astro](https://github.com/withastro/astro/issues/5796) don't support React's attr casing convention, so they have to be left as-is for it to render correctly.

I found this issue through MDX for Astro, while you can type `<x xlink:href="#test" />` as-is in a `.mdx` file and `remark-mdx` escapes it properly to render the attr as-is. If a rehype plugin injects hast, MDX doesn't escape it anymore (rehype comes after remark), making some rehype plugins not work in MDX + Preact/Solid/Astro.

In this case, this blocks Astro: https://github.com/withastro/astro/issues/5796

#### Note

Ideally, if this PR is merged, we have to expose another option from MDX so we can properly toggle in in Astro, as MDX uses it [internally](https://github.com/mdx-js/mdx/blob/f4d78be5c015e8fab48589efae9507d0304e5e94/packages/mdx/lib/plugin/rehype-recma.js#L15).

Since the repo doesn't have a lockfile, `npm install` raise errors which I fixed in the second commit. If this unrelated change is undesired, I can split and make a second PR.

<!--do not edit: pr-->
