### PR TITLE
Fix style properties that are not identifiers

### DIFF
--- a/lib/handlers/element.js
+++ b/lib/handlers/element.js
@@ -105,7 +105,9 @@ export function element(node, state) {
               method: false,
               shorthand: false,
               computed: false,
-              key: {type: 'Identifier', name: cssProp},
+              key: cssProp.includes('-')
+                ? {type: 'Literal', value: cssProp}
+                : {type: 'Identifier', name: cssProp},
               value: {type: 'Literal', value: String(styleObject[cssProp])},
               kind: 'init'
             })

--- a/lib/handlers/element.js
+++ b/lib/handlers/element.js
@@ -16,7 +16,8 @@ import {svg, find, hastToReact} from 'property-information'
 import {stringify as spaces} from 'space-separated-tokens'
 import {
   start as identifierStart,
-  cont as identifierCont
+  cont as identifierCont,
+  name as identifierName
 } from 'estree-util-is-identifier-name'
 import styleToObject from 'style-to-object'
 
@@ -105,9 +106,9 @@ export function element(node, state) {
               method: false,
               shorthand: false,
               computed: false,
-              key: cssProp.includes('-')
-                ? {type: 'Literal', value: cssProp}
-                : {type: 'Identifier', name: cssProp},
+              key: identifierName(cssProp)
+                ? {type: 'Identifier', name: cssProp}
+                : {type: 'Literal', value: cssProp},
               value: {type: 'Literal', value: String(styleObject[cssProp])},
               kind: 'init'
             })

--- a/test.js
+++ b/test.js
@@ -627,7 +627,7 @@ test('toEstree', () => {
       }),
       {handlers: jsx}
     ).value,
-    '<h1 style={{\n  background-color: "red"\n}}>{"x"}</h1>;\n',
+    '<h1 style={{\n  "background-color": "red"\n}}>{"x"}</h1>;\n',
     "should support `stylePropertyNameCase: 'css'`"
   )
 
@@ -641,7 +641,7 @@ test('toEstree', () => {
       ),
       {handlers: jsx}
     ).value,
-    '<h1 style={{\n  WebkitTransform: "rotate(0.01turn)",\n  msTransform: "rotate(0.01turn)",\n  --fg: "#0366d6",\n  color: "var(--fg)"\n}} />;\n',
+    '<h1 style={{\n  WebkitTransform: "rotate(0.01turn)",\n  msTransform: "rotate(0.01turn)",\n  "--fg": "#0366d6",\n  color: "var(--fg)"\n}} />;\n',
     'should support vendor prefixes and css variables (dom)'
   )
 
@@ -656,7 +656,7 @@ test('toEstree', () => {
       ),
       {handlers: jsx}
     ).value,
-    '<h1 style={{\n  -webkit-transform: "rotate(0.01turn)",\n  -ms-transform: "rotate(0.01turn)",\n  --fg: "#0366d6",\n  color: "var(--fg)"\n}} />;\n',
+    '<h1 style={{\n  "-webkit-transform": "rotate(0.01turn)",\n  "-ms-transform": "rotate(0.01turn)",\n  "--fg": "#0366d6",\n  color: "var(--fg)"\n}} />;\n',
     'should support vendor prefixes and css variables (css)'
   )
 })


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

After the addition of `stylePropertyNameCase`, the JSX output contained style objects that didn't wrap hyphenated properties with quotes. This is invalid JavaScript/JSX.

This PR makes it check for hyphens inside the property name, and exports a `Literal` instead of an `Identifier`. This seems to also fix the same issue for CSS variables, which also seem to be problematic in this regard.

<!--do not edit: pr-->
